### PR TITLE
Login Bug Fix: Upon logging in, users remain on the same page instead of redirecting to /admin

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -91,7 +91,7 @@ export async function loginGoogle(
   const result = await fetchGql<LoginGoogle>({
     query: `
       mutation LoginGoogle($accessToken: String!) {
-        loginGoogle(accessToken: $accessToken") {
+        loginGoogle(accessToken: $accessToken) {
           user {
             name
             email


### PR DESCRIPTION
I fixed the login bug to redirect to /admin. There was a syntax error that caused this issue, but it works now. Everything was tested before this pull request.